### PR TITLE
Adds ISL AST generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,6 +80,7 @@ OBJS = $(BIN)/RectangularDomain.o \
 			 $(BIN)/FusionTransformation.o \
 			 $(BIN)/ShiftTransformation.o \
 			 $(BIN)/TileTransformation.o \
+			 $(BIN)/IslAstRoot.o \
 			 $(BIN)/util.o
 
 

--- a/src/IslAstRoot.cpp
+++ b/src/IslAstRoot.cpp
@@ -1,0 +1,3 @@
+#include "IslAstRoot.hpp"
+
+IslAstRoot::IslAstRoot( isl_ast_node* root, isl_ctx* ctx ): root(root), ctx(ctx) {}

--- a/src/IslAstRoot.hpp
+++ b/src/IslAstRoot.hpp
@@ -1,0 +1,14 @@
+#ifndef ISLASTROOT_HPP
+#define ISLASTROOT_HPP
+
+#include "all_isl.hpp"
+
+class IslAstRoot{
+  public:
+    isl_ast_node* root;
+    isl_ctx* ctx;
+
+    IslAstRoot( isl_ast_node* root, isl_ctx* ctx );
+};
+
+#endif

--- a/src/Schedule.hpp
+++ b/src/Schedule.hpp
@@ -14,11 +14,14 @@ Copyright 2015 Colorado State University
 #include "LoopChain.hpp"
 #include "RectangularDomain.hpp"
 #include "Transformation.hpp"
+#include "IslAstRoot.hpp"
+#include "all_isl.hpp"
 #include "util.hpp"
 #include <string>
 #include <vector>
 #include <iostream>
 #include <sstream>
+
 
 // Forward declarations because C++ was a mistake.
 namespace LoopChainIR {
@@ -181,7 +184,7 @@ namespace LoopChainIR {
     /*!
     \brief
     Transform the initial loop chain using the applied trasformations and
-    generate the resulting loop code to a file.
+    generate the resulting loop code to a file via ISL's code printer.
 
     \param[in] file_name Path to file being written.
 
@@ -189,6 +192,16 @@ namespace LoopChainIR {
     bool true if stream good and not fail and not bad
     */
     bool codegenToFile( std::string file_name );
+
+    /*!
+    \brief
+    Transform the initial loop chain using the applied trasformations and
+    generate the resulting loop code to ISL AST.
+
+    \returns
+    Pointer to isl_ast_node struct.
+    */
+    IslAstRoot* codegenToIslAst();
 
   public:
     friend std::ostream& LoopChainIR::operator<<( std::ostream& os, const Schedule& schedule);


### PR DESCRIPTION
+ Schedule now can return the the ISL AST (and context) of code
generation via IslAstRoot
+ Adds IslAstRoot wrapper for isl_ast_node and isl_ctx pointers
