### PR TITLE
Changes RectangularDomain to use set for symbols

### DIFF
--- a/src/RectangularDomain.cpp
+++ b/src/RectangularDomain.cpp
@@ -25,13 +25,11 @@ RectangularDomain::RectangularDomain( std::string input_lower_bounds, std::strin
 
 }
 
-RectangularDomain::RectangularDomain( std::string input_lower_bounds, std::string input_upper_bounds, const std::set<std::string> symbols ){
+RectangularDomain::RectangularDomain( std::string input_lower_bounds, std::string input_upper_bounds, const std::set<std::string> symbols )
+: symbols( symbols )
+{
   this->lower_bounds.push_back( input_lower_bounds );
   this->upper_bounds.push_back( input_upper_bounds );
-
-  for( std::set<std::string>::const_iterator iter = symbols.begin(); iter != symbols.end(); ++iter ){
-    this->symbols.push_back( std::string(*iter) );
-  }
 }
 
 RectangularDomain::RectangularDomain( std::string input_lower_bounds[], std::string input_upper_bounds[], size_type dimensions ){
@@ -58,12 +56,14 @@ RectangularDomain::RectangularDomain( std::string input_lower_bounds[], std::str
   }
 
   for( size_type d = 0; d < symbolics; d += 1 ){
-    this->symbols.push_back( symbols[d] );
+    this->symbols.insert( symbols[d] );
   }
 
 }
 
-RectangularDomain::RectangularDomain( std::string input_lower_bounds[], std::string input_upper_bounds[], size_type dimensions, const std::set<std::string> symbols ){
+RectangularDomain::RectangularDomain( std::string input_lower_bounds[], std::string input_upper_bounds[], size_type dimensions, const std::set<std::string> symbols )
+: symbols( symbols )
+{
   assertWithException( input_lower_bounds != NULL, "Lower bounds array cannot be null" );
   assertWithException( input_upper_bounds != NULL, "Upper bounds array cannot be null" );
   assertWithException( dimensions >= 1, "Cannot have domain with fewer than one dimension" );
@@ -73,13 +73,10 @@ RectangularDomain::RectangularDomain( std::string input_lower_bounds[], std::str
     this->upper_bounds.push_back( input_upper_bounds[d] );
   }
 
-  for( std::set<std::string>::const_iterator iter = symbols.begin(); iter != symbols.end(); ++iter ){
-    this->symbols.push_back( std::string(*iter) );
-  }
 }
 
 void RectangularDomain::append( RectangularDomain other){
-  this->symbols.insert( this->symbols.end(), other.symbols.begin(), other.symbols.end() );
+  this->symbols.insert( other.symbols.begin(), other.symbols.end() );
   for( size_type d = 0; d < other.dimensions(); d += 1 ){
     this->lower_bounds.push_back( other.getLowerBound(d) );
     this->upper_bounds.push_back( other.getUpperBound(d) );
@@ -102,6 +99,6 @@ std::string RectangularDomain::getLowerBound( RectangularDomain::size_type dimen
   return this->lower_bounds[dimension];
 }
 
-std::string RectangularDomain::getSymbol( RectangularDomain::size_type symbolic ){
-  return this->symbols[symbolic];
+std::set<std::string> RectangularDomain::getSymbols( ){
+  return this->symbols;
 }

--- a/src/RectangularDomain.hpp
+++ b/src/RectangularDomain.hpp
@@ -30,7 +30,7 @@ namespace LoopChainIR{
   private:
     std::vector<std::string> upper_bounds;
     std::vector<std::string> lower_bounds;
-    std::vector<std::string> symbols;
+    std::set<std::string> symbols;
 
   public:
     typedef std::vector<std::string>::size_type size_type;
@@ -100,9 +100,9 @@ namespace LoopChainIR{
     std::string getLowerBound( size_type dimension );
 
     /*!
-    \returns the N'th symbol from the list as it was provided to the constructor.
+    \returns the set of symbols.
     */
-    std::string getSymbol( size_type symbolic );
+    std::set<std::string> getSymbols( );
 
   };
 

--- a/src/Schedule.cpp
+++ b/src/Schedule.cpp
@@ -46,11 +46,11 @@ Schedule::Schedule( LoopChain& chain, std::string statement_prefix ) :
     std::ostringstream symbolic_string;
 
     bool is_not_first_symbolic = false; // for comma insertion
-    for( RectangularDomain::size_type symbolic = 0; symbolic < domain.symbolics(); symbolic += 1 ){
+    for( auto symbol : domain.getSymbols() ){
       if( is_not_first_symbolic ){
         symbolic_string << ",";
       }
-      symbolic_string << domain.getSymbol(symbolic);
+      symbolic_string << symbol;
       is_not_first_symbolic = true;
     }
 

--- a/test/unit-tests/src/LoopChain_test.cpp
+++ b/test/unit-tests/src/LoopChain_test.cpp
@@ -59,39 +59,53 @@ TEST(LoopChainTest, Test_Getters_4N_1D) {
   // Test
   EXPECT_EQ( chain.length(), 4 );
 
-  RectangularDomain got_domain = chain.getNest(0).getDomain();
+  {
+    RectangularDomain got_domain = chain.getNest(0).getDomain();
 
-  EXPECT_EQ( got_domain.dimensions(), 1 );
-  EXPECT_EQ( got_domain.symbolics(), 1 );
-  EXPECT_EQ( got_domain.getLowerBound(0), string("0") );
-  EXPECT_EQ( got_domain.getUpperBound(0), string("J") );
-  EXPECT_EQ( got_domain.getSymbol(0), "J" );
+    EXPECT_EQ( got_domain.dimensions(), 1 );
+    EXPECT_EQ( got_domain.symbolics(), 1 );
+    EXPECT_EQ( got_domain.getLowerBound(0), string("0") );
+    EXPECT_EQ( got_domain.getUpperBound(0), string("J") );
+    string arr_sym[1] = { "J" };
+    set<string> form_symbols( arr_sym, arr_sym+1 );
+    EXPECT_EQ( got_domain.getSymbols(), form_symbols );
+  }
 
-  got_domain = chain.getNest(1).getDomain();
+  {
+    RectangularDomain got_domain = chain.getNest(1).getDomain();
 
-  EXPECT_EQ( got_domain.dimensions(), 1 );
-  EXPECT_EQ( got_domain.symbolics(), 1 );
-  EXPECT_EQ( got_domain.getLowerBound(0), string("1") );
-  EXPECT_EQ( got_domain.getUpperBound(0), string("K") );
-  EXPECT_EQ( got_domain.getSymbol(0), "K" );
+    EXPECT_EQ( got_domain.dimensions(), 1 );
+    EXPECT_EQ( got_domain.symbolics(), 1 );
+    EXPECT_EQ( got_domain.getLowerBound(0), string("1") );
+    EXPECT_EQ( got_domain.getUpperBound(0), string("K") );
+    string arr_sym[1] = { "K" };
+    set<string> form_symbols( arr_sym, arr_sym+1 );
+    EXPECT_EQ( got_domain.getSymbols(), form_symbols );
+  }
 
+  {
+    RectangularDomain got_domain = chain.getNest(2).getDomain();
 
-  got_domain = chain.getNest(2).getDomain();
+    EXPECT_EQ( got_domain.dimensions(), 1 );
+    EXPECT_EQ( got_domain.symbolics(), 1 );
+    EXPECT_EQ( got_domain.getLowerBound(0), string("2") );
+    EXPECT_EQ( got_domain.getUpperBound(0), string("L") );
+    string arr_sym[1] = { "L" };
+    set<string> form_symbols( arr_sym, arr_sym+1 );
+    EXPECT_EQ( got_domain.getSymbols(), form_symbols );
+  }
 
-  EXPECT_EQ( got_domain.dimensions(), 1 );
-  EXPECT_EQ( got_domain.symbolics(), 1 );
-  EXPECT_EQ( got_domain.getLowerBound(0), string("2") );
-  EXPECT_EQ( got_domain.getUpperBound(0), string("L") );
-  EXPECT_EQ( got_domain.getSymbol(0), "L" );
+  {
+    RectangularDomain got_domain = chain.getNest(3).getDomain();
 
-
-  got_domain = chain.getNest(3).getDomain();
-
-  EXPECT_EQ( got_domain.dimensions(), 1 );
-  EXPECT_EQ( got_domain.symbolics(), 1 );
-  EXPECT_EQ( got_domain.getLowerBound(0), string("3") );
-  EXPECT_EQ( got_domain.getUpperBound(0), string("M") );
-  EXPECT_EQ( got_domain.getSymbol(0), "M" );
+    EXPECT_EQ( got_domain.dimensions(), 1 );
+    EXPECT_EQ( got_domain.symbolics(), 1 );
+    EXPECT_EQ( got_domain.getLowerBound(0), string("3") );
+    EXPECT_EQ( got_domain.getUpperBound(0), string("M") );
+    string arr_sym[1] = { "M" };
+    set<string> form_symbols( arr_sym, arr_sym+1 );
+    EXPECT_EQ( got_domain.getSymbols(), form_symbols );
+  }
 }
 
 TEST(LoopChainTest, TestNew) {
@@ -137,23 +151,31 @@ TEST(LoopChainTest, Test_Getters_2N_1D_2D) {
   // Test
   EXPECT_EQ( chain.length(), 2 );
 
-  RectangularDomain got_domain = chain.getNest(0).getDomain();
+  {
+    RectangularDomain got_domain = chain.getNest(0).getDomain();
 
-  EXPECT_EQ( got_domain.dimensions(), 1 );
-  EXPECT_EQ( got_domain.symbolics(), 1 );
-  EXPECT_EQ( got_domain.getLowerBound(0), string("0") );
-  EXPECT_EQ( got_domain.getUpperBound(0), string("J") );
-  EXPECT_EQ( got_domain.getSymbol(0), "J" );
+    EXPECT_EQ( got_domain.dimensions(), 1 );
+    EXPECT_EQ( got_domain.symbolics(), 1 );
+    EXPECT_EQ( got_domain.getLowerBound(0), string("0") );
+    EXPECT_EQ( got_domain.getUpperBound(0), string("J") );
+    string arr_sym[1] = { "J" };
+    set<string> form_symbols( arr_sym, arr_sym+1 );
+    EXPECT_EQ( got_domain.getSymbols(), form_symbols );
+  }
 
-  got_domain = chain.getNest(1).getDomain();
+  {
+    RectangularDomain got_domain = chain.getNest(1).getDomain();
 
-  EXPECT_EQ( got_domain.dimensions(), 2 );
-  EXPECT_EQ( got_domain.symbolics(), 1 );
-  EXPECT_EQ( got_domain.getLowerBound(0), string("1") );
-  EXPECT_EQ( got_domain.getUpperBound(0), string("K") );
-  EXPECT_EQ( got_domain.getLowerBound(1), string("2") );
-  EXPECT_EQ( got_domain.getUpperBound(1), string("3") );
-  EXPECT_EQ( got_domain.getSymbol(0), "K" );
+    EXPECT_EQ( got_domain.dimensions(), 2 );
+    EXPECT_EQ( got_domain.symbolics(), 1 );
+    EXPECT_EQ( got_domain.getLowerBound(0), string("1") );
+    EXPECT_EQ( got_domain.getUpperBound(0), string("K") );
+    EXPECT_EQ( got_domain.getLowerBound(1), string("2") );
+    EXPECT_EQ( got_domain.getUpperBound(1), string("3") );
+    string arr_sym[1] = { "K" };
+    set<string> form_symbols( arr_sym, arr_sym+1 );
+    EXPECT_EQ( got_domain.getSymbols(), form_symbols );
+  }
 }
 
 /*
@@ -182,23 +204,31 @@ TEST(LoopChainTest, Test_Getters_2N_2D_1D) {
   // Test
   EXPECT_EQ( chain.length(), 2 );
 
-  RectangularDomain got_domain = chain.getNest(0).getDomain();
+  {
+    RectangularDomain got_domain = chain.getNest(0).getDomain();
 
-  EXPECT_EQ( got_domain.dimensions(), 2 );
-  EXPECT_EQ( got_domain.symbolics(), 1 );
-  EXPECT_EQ( got_domain.getLowerBound(0), string("1") );
-  EXPECT_EQ( got_domain.getUpperBound(0), string("K") );
-  EXPECT_EQ( got_domain.getLowerBound(1), string("2") );
-  EXPECT_EQ( got_domain.getUpperBound(1), string("3") );
-  EXPECT_EQ( got_domain.getSymbol(0), "K" );
+    EXPECT_EQ( got_domain.dimensions(), 2 );
+    EXPECT_EQ( got_domain.symbolics(), 1 );
+    EXPECT_EQ( got_domain.getLowerBound(0), string("1") );
+    EXPECT_EQ( got_domain.getUpperBound(0), string("K") );
+    EXPECT_EQ( got_domain.getLowerBound(1), string("2") );
+    EXPECT_EQ( got_domain.getUpperBound(1), string("3") );
+    string arr_sym[1] = { "K" };
+    set<string> form_symbols( arr_sym, arr_sym+1 );
+    EXPECT_EQ( got_domain.getSymbols(), form_symbols );
+  }
 
-  got_domain = chain.getNest(1).getDomain();
+  {
+    RectangularDomain got_domain = chain.getNest(1).getDomain();
 
-  EXPECT_EQ( got_domain.dimensions(), 1 );
-  EXPECT_EQ( got_domain.symbolics(), 1 );
-  EXPECT_EQ( got_domain.getLowerBound(0), string("0") );
-  EXPECT_EQ( got_domain.getUpperBound(0), string("J") );
-  EXPECT_EQ( got_domain.getSymbol(0), "J" );
+    EXPECT_EQ( got_domain.dimensions(), 1 );
+    EXPECT_EQ( got_domain.symbolics(), 1 );
+    EXPECT_EQ( got_domain.getLowerBound(0), string("0") );
+    EXPECT_EQ( got_domain.getUpperBound(0), string("J") );
+    string arr_sym[1] = { "J" };
+    set<string> form_symbols( arr_sym, arr_sym+1 );
+    EXPECT_EQ( got_domain.getSymbols(), form_symbols );
+  }
 }
 
 /*
@@ -234,36 +264,45 @@ TEST(LoopChainTest, Test_Getters_3N_1D_2D_3D) {
   // Test
   EXPECT_EQ( chain.length(), 3 );
 
-  RectangularDomain got_domain = chain.getNest(0).getDomain();
+  {
+    RectangularDomain got_domain = chain.getNest(0).getDomain();
 
-  EXPECT_EQ( got_domain.dimensions(), 1 );
-  EXPECT_EQ( got_domain.symbolics(), 1 );
-  EXPECT_EQ( got_domain.getLowerBound(0), string("0") );
-  EXPECT_EQ( got_domain.getUpperBound(0), string("J") );
-  EXPECT_EQ( got_domain.getSymbol(0), "J" );
+    EXPECT_EQ( got_domain.dimensions(), 1 );
+    EXPECT_EQ( got_domain.symbolics(), 1 );
+    EXPECT_EQ( got_domain.getLowerBound(0), string("0") );
+    EXPECT_EQ( got_domain.getUpperBound(0), string("J") );
+    string arr_sym[1] = { "J" };
+    set<string> form_symbols( arr_sym, arr_sym+1 );
+    EXPECT_EQ( got_domain.getSymbols(), form_symbols );
+  }
 
-  got_domain = chain.getNest(1).getDomain();
+  {
+    RectangularDomain got_domain = chain.getNest(1).getDomain();
 
-  EXPECT_EQ( got_domain.dimensions(), 2 );
-  EXPECT_EQ( got_domain.symbolics(), 1 );
-  EXPECT_EQ( got_domain.getLowerBound(0), string("1") );
-  EXPECT_EQ( got_domain.getUpperBound(0), string("K") );
-  EXPECT_EQ( got_domain.getLowerBound(1), string("2") );
-  EXPECT_EQ( got_domain.getUpperBound(1), string("3") );
-  EXPECT_EQ( got_domain.getSymbol(0), "K" );
+    EXPECT_EQ( got_domain.dimensions(), 2 );
+    EXPECT_EQ( got_domain.symbolics(), 1 );
+    EXPECT_EQ( got_domain.getLowerBound(0), string("1") );
+    EXPECT_EQ( got_domain.getUpperBound(0), string("K") );
+    EXPECT_EQ( got_domain.getLowerBound(1), string("2") );
+    EXPECT_EQ( got_domain.getUpperBound(1), string("3") );
+    string arr_sym[1] = { "K" };
+    set<string> form_symbols( arr_sym, arr_sym+1 );
+    EXPECT_EQ( got_domain.getSymbols(), form_symbols );
+  }
 
-  got_domain = chain.getNest(2).getDomain();
+  {
+    RectangularDomain got_domain = chain.getNest(2).getDomain();
 
-  EXPECT_EQ( got_domain.dimensions(), 3 );
-  EXPECT_EQ( got_domain.symbolics(), 4 );
-  EXPECT_EQ( got_domain.getLowerBound(0), string("L") );
-  EXPECT_EQ( got_domain.getUpperBound(0), string("K") );
-  EXPECT_EQ( got_domain.getLowerBound(1), string("M") );
-  EXPECT_EQ( got_domain.getUpperBound(1), string("3") );
-  EXPECT_EQ( got_domain.getLowerBound(2), string("N") );
-  EXPECT_EQ( got_domain.getUpperBound(2), string("5") );
-  EXPECT_EQ( got_domain.getSymbol(0), "K" );
-  EXPECT_EQ( got_domain.getSymbol(1), "L" );
-  EXPECT_EQ( got_domain.getSymbol(2), "M" );
-  EXPECT_EQ( got_domain.getSymbol(3), "N" );
+    EXPECT_EQ( got_domain.dimensions(), 3 );
+    EXPECT_EQ( got_domain.symbolics(), 4 );
+    EXPECT_EQ( got_domain.getLowerBound(0), string("L") );
+    EXPECT_EQ( got_domain.getUpperBound(0), string("K") );
+    EXPECT_EQ( got_domain.getLowerBound(1), string("M") );
+    EXPECT_EQ( got_domain.getUpperBound(1), string("3") );
+    EXPECT_EQ( got_domain.getLowerBound(2), string("N") );
+    EXPECT_EQ( got_domain.getUpperBound(2), string("5") );
+    string arr_sym[4] = { "K", "L", "M", "N" };
+    set<string> form_symbols( arr_sym, arr_sym+4 );
+    EXPECT_EQ( got_domain.getSymbols(), form_symbols );
+  }
 }

--- a/test/unit-tests/src/LoopNest_test.cpp
+++ b/test/unit-tests/src/LoopNest_test.cpp
@@ -42,9 +42,7 @@ TEST(LoopNestTest, Test_Getters_1D) {
     EXPECT_EQ( got_domain.getUpperBound(d), domain.getUpperBound(d) );
   }
 
-  for( RectangularDomain::size_type s = 0; s < got_domain.symbolics(); s += 1 ){
-    EXPECT_EQ( got_domain.getSymbol(s), domain.getSymbol(s) );
-  }
+  EXPECT_EQ( got_domain.getSymbols(), domain.getSymbols() );
 }
 
 /*
@@ -76,7 +74,5 @@ TEST(LoopNestTest, Test_Getters_1D_Symbols) {
     EXPECT_EQ( got_domain.getUpperBound(d), domain.getUpperBound(d) );
   }
 
-  for( RectangularDomain::size_type s = 0; s < got_domain.symbolics(); s += 1 ){
-    EXPECT_EQ( got_domain.getSymbol(s), domain.getSymbol(s) );
-  }
+  EXPECT_EQ( got_domain.getSymbols(), domain.getSymbols() );
 }

--- a/test/unit-tests/src/RectangularDomain_test.cpp
+++ b/test/unit-tests/src/RectangularDomain_test.cpp
@@ -101,8 +101,9 @@ TEST(RectangularDomainTest, Test_Append_Symbols ) {
   EXPECT_EQ( domain->getUpperBound(0), "N" );
   EXPECT_EQ( domain->getLowerBound(1), "L" );
   EXPECT_EQ( domain->getUpperBound(1), "1" );
-  EXPECT_EQ( domain->getSymbol(0), "N" );
-  EXPECT_EQ( domain->getSymbol(1), "L" );
+  string arr_sym[2] = { "N", "L" };
+  set<string> form_symbols( arr_sym, arr_sym+2 );
+  EXPECT_EQ( domain->getSymbols(), form_symbols );
 }
 
 /*
@@ -146,7 +147,9 @@ TEST(RectangularDomainTest, Test_Getters_2D_Symbols) {
   EXPECT_EQ( domain.getUpperBound(0), "1" );
   EXPECT_EQ( domain.getLowerBound(1), "0" );
   EXPECT_EQ( domain.getUpperBound(1), "N" );
-  EXPECT_EQ( domain.getSymbol(0), "N" );
+  string arr_sym[1] = { "N" };
+  set<string> form_symbols( arr_sym, arr_sym+1 );
+  EXPECT_EQ( domain.getSymbols(), form_symbols );
 }
 
 /*
@@ -169,8 +172,9 @@ TEST(RectangularDomainTest, Test_Getters_2D_Symbols_2) {
   EXPECT_EQ( domain.getUpperBound(0), "1" );
   EXPECT_EQ( domain.getLowerBound(1), "0" );
   EXPECT_EQ( domain.getUpperBound(1), "N" );
-  EXPECT_EQ( domain.getSymbol(0), "L" );
-  EXPECT_EQ( domain.getSymbol(1), "N" );
+  string arr_sym[2] = { "L", "N" };
+  set<string> form_symbols( arr_sym, arr_sym+2 );
+  EXPECT_EQ( domain.getSymbols(), form_symbols );
 }
 
 /*
@@ -233,8 +237,9 @@ TEST(RectangularDomainTest, Test_Getters_2D_Expressions_Symbols) {
   EXPECT_EQ( domain.getUpperBound(0), "N * 2" );
   EXPECT_EQ( domain.getLowerBound(1), "L * 2" );
   EXPECT_EQ( domain.getUpperBound(1), "N * N" );
-  EXPECT_EQ( domain.getSymbol(0), "L" );
-  EXPECT_EQ( domain.getSymbol(1), "N" );
+  string arr_sym[2] = { "L", "N" };
+  set<string> form_symbols( arr_sym, arr_sym+2 );
+  EXPECT_EQ( domain.getSymbols(), form_symbols );
 }
 
 /*
@@ -256,10 +261,7 @@ TEST(RectangularDomainTest, Test_Getters_1D_Expressions_Symbols_Set) {
   EXPECT_EQ( domain.symbolics(), 2 );
   EXPECT_EQ( domain.getLowerBound(0), "L - 15" );
   EXPECT_EQ( domain.getUpperBound(0), "N * 2" );
-  set<string> symbols_check;
-  symbols_check.insert( domain.getSymbol(0) );
-  symbols_check.insert( domain.getSymbol(1) );
-  EXPECT_EQ( symbols_check, symbols );
+  EXPECT_EQ( domain.getSymbols(), symbols );
 }
 
 /*
@@ -283,8 +285,5 @@ TEST(RectangularDomainTest, Test_Getters_2D_Expressions_Symbols_Set) {
   EXPECT_EQ( domain.getUpperBound(0), "N * 2" );
   EXPECT_EQ( domain.getLowerBound(1), "L * 2" );
   EXPECT_EQ( domain.getUpperBound(1), "N * N" );
-  set<string> symbols_check;
-  symbols_check.insert( domain.getSymbol(0) );
-  symbols_check.insert( domain.getSymbol(1) );
-  EXPECT_EQ( symbols_check, symbols );
+  EXPECT_EQ( domain.getSymbols(), symbols );
 }

--- a/test/unit-tests/src/ShiftTransformation_test.cpp
+++ b/test/unit-tests/src/ShiftTransformation_test.cpp
@@ -14,6 +14,7 @@ Copyright 2015 Colorado State University
 #include <iostream>
 #include <utility>
 
+
 using namespace std;
 using namespace LoopChainIR;
 


### PR DESCRIPTION
Previously RectangularDomain used a vector of strings to represent the symbolic constants. 
This was a poor design and causes ISL to fail downstream when multiple domains are appended which have a non-empty intersection of symbols, causing repeating symbols.

This PR fixes this, and updates tests accordingly.

All tests pass.